### PR TITLE
Fix docs-skeleton to run without warnings

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,7 +1,7 @@
 # This action runs when a pull request to main is created or updated
 # (but not when it is merged into main).
 
-name: CI on pull request create or update
+name: Test build for PRs
 on:
   pull_request_target:
     branches:
@@ -47,7 +47,6 @@ jobs:
           # install tagged version
           python -m pip install -r docs/requirements.txt
 
-XXX
       - name: Set dynamic environment variables.
         run: |
           echo "RUN_DATE=$(date +'%Y-%m-%dT%H%M')" >> $GITHUB_ENV
@@ -56,7 +55,6 @@ XXX
         run: |
           sphinx-build --nitpicky --fail-on-warning --keep-going docs docs/_build
           cp -r docs/_build/. publish/
-
 
       - name: Store publish dir (=pages) as artifact
         # This step is not required and may be removed.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,13 +2,10 @@
 #
 # Workflow steps:
 # - checkout gh-pages for updating
-# - create joined vocabulary file in addition to split version
-# - create excel-file from turtle
-# - build pyLODE docs
 # - build sphinx docs/site
-# - publish docs, vocabulary-turtle files and excel-file to gh-pages
+# - publish new docs to gh-pages
 
-name: Build
+name: Build docs
 on:
   push:
     branches:

--- a/docs/_static/fig_A.svg
+++ b/docs/_static/fig_A.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="fig_A.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="6.3642536"
+     inkscape:cx="78.642372"
+     inkscape:cy="59.00142"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <text
+       xml:space="preserve"
+       style="font-size:11.2889px;font-family:'Arial Rounded MT Bold';-inkscape-font-specification:'Arial Rounded MT Bold, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#8dd35f;stroke:#5aa02c;stroke-width:1;paint-order:markers fill stroke"
+       x="1.9123741"
+       y="10.381562"
+       id="text1"><tspan
+         sodipodi:role="line"
+         id="tspan1"
+         style="stroke-width:1;fill:#8dd35f;stroke:#5aa02c"
+         x="1.9123741"
+         y="10.381562">A</tspan></text>
+  </g>
+</svg>

--- a/docs/_static/fig_B.svg
+++ b/docs/_static/fig_B.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="fig_B.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="6.3642536"
+     inkscape:cx="78.642372"
+     inkscape:cy="59.00142"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ffffff;stroke:#008080;stroke-width:1;paint-order:markers fill stroke"
+       x="2.3281076"
+       y="10.381562"
+       id="text1"><tspan
+         sodipodi:role="line"
+         id="tspan1"
+         x="2.3281076"
+         y="10.381562">B</tspan></text>
+  </g>
+</svg>

--- a/docs/_static/fig_C.svg
+++ b/docs/_static/fig_C.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="fig_C.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="6.3642536"
+     inkscape:cx="78.642372"
+     inkscape:cy="59.00142"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ffffff;stroke:#c8ab37;stroke-width:1;paint-order:markers fill stroke"
+       x="2.3281076"
+       y="10.381562"
+       id="text1"><tspan
+         sodipodi:role="line"
+         id="tspan1">C</tspan></text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,10 @@ This is work in progress...
 ::::{grid} 3
 :::{grid-item-card}
 :link: https://github.com/nfdi4cat/repo4cat/
-**Documentation**, preview
+**Link A**, Anna
 ^^^
 
-```{image} _static/voc4cat-pylode-docs.png
+```{image} _static/fig_A.svg
 :align: center
 :alt: screenshot of documentation
 ```
@@ -23,10 +23,10 @@ This is work in progress...
 
 :::{grid-item-card}
 :link: https://github.com/nfdi4cat/repo4cat/
-**Link 2**, file2
+**Link B**, Berta
 ^^^
 
-```{image} _static/voc4cat-concept-sheet.png
+```{image} _static/fig_B.svg
 :align: center
 :alt: screenshot of file
 ```
@@ -35,11 +35,11 @@ This is work in progress...
 :::
 
 :::{grid-item-card}
-:link: https://w3id.org/nfdi4cat/voc4cat
-**Link 3**, file3
+:link: https://w3id.org/nfdi4cat/repo4cat/
+**Link C**, Charla
 ^^^
 
-```{image} _static/voc4cat-concept-sheet.png
+```{image} _static/fig_C.svg
 :align: center
 :alt: screenshot of file 3
 ```


### PR DESCRIPTION
Add 3 images to avoid warnings. The pipeline is configured to fail on warnings so it could not succeed before.

This also cleans up the gh-actions files (better comments/names).

Related to #39