### PR TITLE
Upgrade to safe jinja2 version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,7 +26,7 @@ idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   myst-parser
     #   sphinx


### PR DESCRIPTION
This updates jinja2 for the documentation build from 3.1.4 to 3.1.5 to address the [security report](https://github.com/nfdi4cat/repo4cat/security).